### PR TITLE
Javascript comments oddity

### DIFF
--- a/rpr-login.php
+++ b/rpr-login.php
@@ -936,10 +936,10 @@ if ( !class_exists( 'RPR_Login' ) ) {
                             var shortPass = 1, badPass = 2, goodPass = 3, strongPass = 4, mismatch = 5, symbolSize = 0, natLog, score;
                             // password 1 !== password 2
                             if (password1 !== password2 && password2.length > 0)
-                                return mismatch
-                            // password < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?>
+                                return mismatch;
+                            /* password < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?> */
                             if (password1.length < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?>)
-                                return shortPass
+                                return shortPass;
                             // password1 === username
                             if (password1.toLowerCase() === username.toLowerCase())
                                 return badPass;
@@ -951,12 +951,12 @@ if ( !class_exists( 'RPR_Login' ) ) {
                                 symbolSize +=26;
                             if (password1.match(/[^a-zA-Z0-9]/))
                                 symbolSize +=31;
-                            natLog = Math.log(Math.pow(symbolSize, password1.length));
+                                natLog = Math.log(Math.pow(symbolSize, password1.length));
                                 score = natLog / Math.LN2;
                             if (score < 40)
-                                return badPass
+                                return badPass;
                             if (score < 56)
-                                return goodPass
+                                return goodPass;
                             return strongPass;
                         }
                         jQuery(document).ready( function() {

--- a/rpr-login.php
+++ b/rpr-login.php
@@ -934,13 +934,10 @@ if ( !class_exists( 'RPR_Login' ) ) {
                             // HACK support disable_password_confirmation in function
                             password2 = typeof password2 !== 'undefined' ? password2 : '';
                             var shortPass = 1, badPass = 2, goodPass = 3, strongPass = 4, mismatch = 5, symbolSize = 0, natLog, score;
-                            // password 1 !== password 2
                             if (password1 !== password2 && password2.length > 0)
                                 return mismatch;
-                            /* password < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?> */
                             if (password1.length < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?>)
                                 return shortPass;
-                            // password1 === username
                             if (password1.toLowerCase() === username.toLowerCase())
                                 return badPass;
                             if (password1.match(/[0-9]/))

--- a/rpr-signup.php
+++ b/rpr-signup.php
@@ -484,10 +484,10 @@ if ( !class_exists( 'RPR_Signup' ) ) {
                         var shortPass = 1, badPass = 2, goodPass = 3, strongPass = 4, mismatch = 5, symbolSize = 0, natLog, score;
                         // password 1 != password 2
                         if ((password1 != password2) && password2.length > 0)
-                            return mismatch
-                        // password < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?>
+                            return mismatch;
+                        /* password < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?> */
                         if (password1.length < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?>)
-                            return shortPass
+                            return shortPass;
                         // password1 == username
                         if (password1.toLowerCase() == username.toLowerCase())
                             return badPass;
@@ -499,12 +499,12 @@ if ( !class_exists( 'RPR_Signup' ) ) {
                             symbolSize +=26;
                         if (password1.match(/[^a-zA-Z0-9]/))
                             symbolSize +=31;
-                        natLog = Math.log(Math.pow(symbolSize, password1.length));
+                            natLog = Math.log(Math.pow(symbolSize, password1.length));
                             score = natLog / Math.LN2;
                         if (score < 40)
-                            return badPass
+                            return badPass;
                         if (score < 56)
-                            return goodPass
+                            return goodPass;
                         return strongPass;
                     }
                     jQuery(document).ready( function() {

--- a/rpr-signup.php
+++ b/rpr-signup.php
@@ -482,13 +482,10 @@ if ( !class_exists( 'RPR_Signup' ) ) {
                         // HACK support disable_password_confirmation in function
                         password2 = typeof password2 !== 'undefined' ? password2 : '';
                         var shortPass = 1, badPass = 2, goodPass = 3, strongPass = 4, mismatch = 5, symbolSize = 0, natLog, score;
-                        // password 1 != password 2
                         if ((password1 != password2) && password2.length > 0)
                             return mismatch;
-                        /* password < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?> */
                         if (password1.length < <?php echo absint( $register_plus_redux->rpr_get_option( 'min_password_length' ) ); ?>)
                             return shortPass;
-                        // password1 == username
                         if (password1.toLowerCase() == username.toLowerCase())
                             return badPass;
                         if (password1.match(/[0-9]/))


### PR DESCRIPTION
1. I've observed a strange behaviour in Firefox browser. A Javascript comment '//' is applied also on the next line in the code. Therefore the condition about a short password is always evaluated as positive. As a workaround I've changed '//' to '/* ... */' which works fine.
2. A few missing semicolons added.

![image](https://user-images.githubusercontent.com/779003/226342661-9a56150f-2b86-4194-927f-b461ac1f7267.png)

=>

![image](https://user-images.githubusercontent.com/779003/226342003-6396b33b-111d-458f-94f3-65f73ea22728.png)

