### PR TITLE
Wrong file path referred in the code

### DIFF
--- a/csstidy/class.csstidy.php
+++ b/csstidy/class.csstidy.php
@@ -41,14 +41,14 @@ require __DIR__ . '/data.inc.php';
  *
  * @version 1.0
  */
-require __DIR__ . '/class.csstidy-print.php';
+require __DIR__ . '/class.csstidy_print.php';
 
 /**
  * Contains a class for optimising CSS code
  *
  * @version 1.0
  */
-require __DIR__ . '/class.csstidy-optimise.php';
+require __DIR__ . '/class.csstidy_optimise.php';
 
 /**
  * CSS Parser class

--- a/rpr-admin-menu.php
+++ b/rpr-admin-menu.php
@@ -34,7 +34,7 @@ if ( !class_exists( 'RPR_Admin_Menu' ) ) {
         public /*.void.*/ function rpr_new_user_notification_warning() {
             global $pagenow;
             if ( 'plugins.php' === $pagenow || ( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'register-plus-redux' === $_GET['page'] ) ) {
-                echo '<div id="register-plus-redux-warning" class="updated"><p><strong>', sprintf( __( 'There is another active plugin that is conflicting with Register Plus Redux. The conflicting plugin is creating its own wp_new_user_notification function, this function is used to alter the messages sent out following the creation of a new user. Please refer to <a href="%s">radiok.info</a> for help resolving this issue.', 'register-plus-redux' ), 'http://radiok.info/blog/wp_new_user_notification-conflicts/' ), '</strong></p></div>', "\n";
+                echo '<div id="register-plus-redux-warning" class="updated"><p><strong>', sprintf( __( 'There is another active plugin that is conflicting with Register Plus Redux. The conflicting plugin is creating its own wp_new_user_notification function, this function is used to alter the messages sent out following the creation of a new user. Please refer to the <a href="%s">project</a> for help resolving this issue.', 'register-plus-redux' ), 'https://github.com/radiok/register-plus-redux/issues' ), '</strong></p></div>', "\n";
             }
         }
 

--- a/rpr-new-user-notification.php
+++ b/rpr-new-user-notification.php
@@ -14,9 +14,9 @@ else {
         global $register_plus_redux;
 
         if ( '1' === $register_plus_redux->rpr_get_option( 'user_set_password' ) && !empty( $_POST['pass1'] ) )
-            $notify = stripslashes( (string) $_POST['pass1'] );
+            $plaintext_pass = stripslashes( (string) $_POST['pass1'] );
         if ( 'user-new.php' === $pagenow && !empty( $_POST['pass1'] ) )
-            $notify = stripslashes( (string) $_POST['pass1'] );
+            $plaintext_pass = stripslashes( (string) $_POST['pass1'] );
         //TODO: Code now only forces users registering to verify email, may want to add settings to have admin created users verify email too
         $verification_code = '';
         if ( 'wp-login.php' === $pagenow && '1' === $register_plus_redux->rpr_get_option( 'verify_user_email' ) ) {
@@ -28,12 +28,12 @@ else {
         if ( ( 'wp-login.php' === $pagenow && '1' !== $register_plus_redux->rpr_get_option( 'disable_user_message_registered' ) ) ||
             ( 'wp-login.php' !== $pagenow && '1' !== $register_plus_redux->rpr_get_option( 'disable_user_message_created' ) ) ) {
             if ( '1' !== $register_plus_redux->rpr_get_option( 'verify_user_email' ) && '1' !== $register_plus_redux->rpr_get_option( 'verify_user_admin' ) ) {
-                $register_plus_redux->send_welcome_user_mail( $user_id, $notify );
+                $register_plus_redux->send_welcome_user_mail( $user_id, $plaintext_pass );
             }
         }
         if ( ( 'wp-login.php' === $pagenow && '1' !== $register_plus_redux->rpr_get_option( 'disable_admin_message_registered' ) ) ||
             ( 'wp-login.php' !== $pagenow && '1' !== $register_plus_redux->rpr_get_option( 'disable_admin_message_created' ) ) ) {
-            $register_plus_redux->send_admin_mail( $user_id, $notify, $verification_code );
+            $register_plus_redux->send_admin_mail( $user_id, $plaintext_pass, $verification_code );
         }
     }
 }

--- a/rpr-new-user-notification.php
+++ b/rpr-new-user-notification.php
@@ -3,16 +3,20 @@
 // Called after admin creates user from wp-admin/user-new.php
 // Called after admin creates new site, which also creates new user from wp-admin/network/edit.php (MS)
 // Called after admin creates user from wp-admin/network/edit.php (MS)
-if ( !function_exists( 'wp_new_user_notification' ) ) {
-    /*.void.*/ function wp_new_user_notification( /*.int.*/ $user_id, $plaintext_pass = '' ) {
+if ( function_exists( 'wp_new_user_notification' ) ) {
+    if ( isset( $rpr_admin_menu ) && $rpr_admin_menu instanceof RPR_Admin_Menu ) {
+        add_action( 'admin_notices', array( $rpr_admin_menu, 'rpr_new_user_notification_warning' ), 10, 0 );
+    }
+}
+else {
+    /*.void.*/ function wp_new_user_notification( /*.int.*/ $user_id, $deprecated = null, /* string */ $notify = '' ) {
         global $pagenow;
         global $register_plus_redux;
 
-        //trigger_error( sprintf( __( 'Register Plus Redux DEBUG: wp_new_user_notification($user_id=%s, $plaintext_pass=%s) from %s', 'register-plus-redux' ), $user_id, $plaintext_pass, $pagenow ) );
         if ( '1' === $register_plus_redux->rpr_get_option( 'user_set_password' ) && !empty( $_POST['pass1'] ) )
-            $plaintext_pass = stripslashes( (string) $_POST['pass1'] );
+            $notify = stripslashes( (string) $_POST['pass1'] );
         if ( 'user-new.php' === $pagenow && !empty( $_POST['pass1'] ) )
-            $plaintext_pass = stripslashes( (string) $_POST['pass1'] );
+            $notify = stripslashes( (string) $_POST['pass1'] );
         //TODO: Code now only forces users registering to verify email, may want to add settings to have admin created users verify email too
         $verification_code = '';
         if ( 'wp-login.php' === $pagenow && '1' === $register_plus_redux->rpr_get_option( 'verify_user_email' ) ) {
@@ -24,17 +28,12 @@ if ( !function_exists( 'wp_new_user_notification' ) ) {
         if ( ( 'wp-login.php' === $pagenow && '1' !== $register_plus_redux->rpr_get_option( 'disable_user_message_registered' ) ) ||
             ( 'wp-login.php' !== $pagenow && '1' !== $register_plus_redux->rpr_get_option( 'disable_user_message_created' ) ) ) {
             if ( '1' !== $register_plus_redux->rpr_get_option( 'verify_user_email' ) && '1' !== $register_plus_redux->rpr_get_option( 'verify_user_admin' ) ) {
-                $register_plus_redux->send_welcome_user_mail( $user_id, $plaintext_pass );
+                $register_plus_redux->send_welcome_user_mail( $user_id, $notify );
             }
         }
         if ( ( 'wp-login.php' === $pagenow && '1' !== $register_plus_redux->rpr_get_option( 'disable_admin_message_registered' ) ) ||
             ( 'wp-login.php' !== $pagenow && '1' !== $register_plus_redux->rpr_get_option( 'disable_admin_message_created' ) ) ) {
-            $register_plus_redux->send_admin_mail( $user_id, $plaintext_pass, $verification_code );
+            $register_plus_redux->send_admin_mail( $user_id, $notify, $verification_code );
         }
     }
 }
-
-if ( function_exists( 'wp_new_user_notification' ) ) {
-    if ( isset( $rpr_admin_menu ) && $rpr_admin_menu instanceof RPR_Admin_Menu ) add_action( 'admin_notices', array( $rpr_admin_menu, 'rpr_new_user_notification_warning' ), 10, 0 );
-}
-?>


### PR DESCRIPTION
1. Wrong file path referred in the code
```
FastCGI sent in stderr: "PHP message: PHP Warning:  require(wp-content/plugins/register-plus-redux/csstidy/class.csstidy-print.php): failed to open stream: No such file or directory in wp-content/plugins/register-plus-redux/csstidy/class.csstidy.php on line 44PHP message: PHP Fatal error:  require(): Failed opening required 'wp-content/plugins/register-plus-redux/csstidy/class.csstidy-print.php' (include_path='.:/usr/share/php') in wp-content/plugins/register-plus-redux/csstidy/class.csstidy.php on line 44" while reading response header from upstream, client: x.x.x.x, server: xxx, request: "POST /wp-admin/admin.php?page=register-plus-redux HTTP/1.0", upstream: "fastcgi://unix:/var/run/php/php7.4-fpm.sock:", host: "xxx", referrer: "https://xxx/wp-admin/admin.php?page=register-plus-redux"
```
2. A permanent conflict warning in the administration
```
There is another active plugin that is conflicting with Register Plus Redux. The conflicting plugin is creating its own wp_new_user_notification function, this function is used to alter the messages sent out following the creation of a new user. Please refer to radiok.info for help resolving this issue.
```
2.1 Function parameters of `wp_new_user_notification` have changed